### PR TITLE
Add Shorebird configuration and update entitlements

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -27,3 +27,5 @@ void main() async {
     ),
   );
 }
+
+/// shorebird patch --platforms=android --release-version=1.0.0+1

--- a/macos/Runner/Release.entitlements
+++ b/macos/Runner/Release.entitlements
@@ -4,5 +4,7 @@
 <dict>
 	<key>com.apple.security.app-sandbox</key>
 	<true/>
+	<key>com.apple.security.network.client</key>
+	<true/>
 </dict>
 </plist>

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -51,6 +51,7 @@ flutter:
     - assets/svg/
     - assets/icons/
     - .env
+    - shorebird.yaml
 
   fonts:
     - family: Avenir Arabic

--- a/shorebird.yaml
+++ b/shorebird.yaml
@@ -1,0 +1,14 @@
+# This file is used to configure the Shorebird updater used by your app.
+# Learn more at https://docs.shorebird.dev
+# This file does not contain any sensitive information and should be checked into version control.
+
+# Your app_id is the unique identifier assigned to your app.
+# It is used to identify your app when requesting patches from Shorebird's servers.
+# It is not a secret and can be shared publicly.
+app_id: e9a0057c-f733-4a6a-bc09-c7c138497aa9
+
+# auto_update controls if Shorebird should automatically update in the background on launch.
+# If auto_update: false, you will need to use package:shorebird_code_push to trigger updates.
+# https://pub.dev/packages/shorebird_code_push
+# Uncomment the following line to disable automatic updates.
+# auto_update: false


### PR DESCRIPTION
This commit introduces a new Shorebird configuration file (shorebird.yaml) to manage app updates and includes the app ID for identification. Additionally, it updates the macOS entitlements to allow network client access, which is necessary for Shorebird's functionality. The main.dart file is also modified to include a Shorebird patch comment for versioning. Finally, the pubspec.yaml is updated to include the new shorebird.yaml in the assets.